### PR TITLE
  Add app generation options to files module

### DIFF
--- a/dev/modules/dogfood.nix
+++ b/dev/modules/dogfood.nix
@@ -4,7 +4,10 @@
 
   perSystem = psArgs: {
     treefmt.projectRoot = inputs.files;
-    files.gitToplevel = inputs.files;
+    files = {
+      gitToplevel = inputs.files;
+      generateWriterApp = true;
+    };
     make-shells.default.packages = [ psArgs.config.files.writer.drv ];
   };
 }

--- a/module.nix
+++ b/module.nix
@@ -102,6 +102,8 @@
             );
           };
 
+          generateWriterApp = lib.mkEnableOption "generating an app for the writer executable";
+
           writer = {
             exeFilename = lib.mkOption {
               type = lib.types.singleLineStr;
@@ -167,6 +169,14 @@
           ))
           lib.listToAttrs
         ];
+
+        apps = lib.mkIf cfg.generateWriterApp {
+          ${cfg.writer.exeFilename} = {
+            type = "app";
+            program = "${cfg.writer.drv}/bin/${cfg.writer.exeFilename}";
+            meta.description = "Write all configured files to their paths";
+          };
+        };
       };
     }
   );


### PR DESCRIPTION
Apps allow running nix run .#write-files to write all files.

This extends the module's functionality from just checks and writer derivation to include user-friendly apps for file operations.