### PR TITLE
Skip substituter checks for trivial builders

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -147,6 +147,11 @@
             ])
             lib.concatLines
           ];
+
+          derivationArgs = {
+            allowSubstitutes = false;
+            preferLocalBuild = true;
+          };
         };
 
         checks = lib.pipe cfg.files [
@@ -165,7 +170,7 @@
                         (pkgs.writeText "flake-files-file")
                       ];
                 in
-                pkgs.runCommand "flake-file-check"
+                pkgs.runCommandLocal "flake-file-check"
                   {
                     nativeBuildInputs = [ pkgs.difftastic ];
                   }


### PR DESCRIPTION
The file generation derivation and the flake check derivation are both trivial local builds — just writing/diffing text files. There's no point hitting substituters for these, and skipping the check speeds up evaluation noticeably.

- Set `allowSubstitutes = false` + `preferLocalBuild = true` on the file builder's `derivationArgs`
- Switch the check from `runCommand` to `runCommandLocal`